### PR TITLE
[docs] Add documentation for slice_worker function

### DIFF
--- a/content/docs/commands/advanced/obiscript/_index.md
+++ b/content/docs/commands/advanced/obiscript/_index.md
@@ -21,7 +21,8 @@ to maintain a running counter across all records, or merging external data sourc
 
 The script is structured around three optional Lua functions. 
 
-- The `worker(sequence)` function is the core: it is called once per input sequence record, receives the record as a `BioSequence` object, and must return the (possibly modified) record, or set or sequence records, or `nil` to drop the current sequence from the output. 
+- The `worker(sequence)` function is the core: it is called once per input sequence record, receives the record as a `BioSequence` object, and must return the (possibly modified) record, or a set of sequence records, or `nil` to drop the current sequence from the output.
+- The `slice_worker(slice)` function is an alternative to `worker`: instead of receiving one sequence at a time, it receives a whole batch (`BioSequenceSlice`) and must return a `BioSequenceSlice`. This is useful when a single operation can cover the entire batch — for example, a single HTTP request to an external server for all sequences at once. If both `slice_worker` and `worker` are defined in the same script, `slice_worker` takes precedence.
 - The `begin()` function runs once before any record is processed and is typically used for initialisation. 
 - The `finish()` function runs once after the last record and is typically used to print summary statistics. A thread-safe key-value table called `obicontext` is shared across all parallel worker invocations and can be used to accumulate results safely.
 
@@ -89,8 +90,8 @@ obiscript [--script|-S SCRIPT] [--template]
 
 - {{< cmd-option name="script" short="S" param="SCRIPT" >}}
   Path to the Lua script file to execute. The file must exist and be syntactically
-  valid Lua. The script should define a `worker(sequence)` function, and optionally
-  `begin()` and `finish()`.
+  valid Lua. The script should define either a `worker(sequence)` function or a
+  `slice_worker(slice)` function, and optionally `begin()` and `finish()`.
   {{< /cmd-option >}}
 
 - {{< cmd-option name="template" >}}

--- a/content/docs/programming/lua/_index.md
+++ b/content/docs/programming/lua/_index.md
@@ -79,6 +79,47 @@ function worker(sequence)
 end
 ```
 
+### The `slice_worker` function
+
+The `slice_worker` function is an alternative to `worker` for batch-level processing. Instead of being called once per sequence, it receives an entire batch as a `BioSequenceSlice` and must return a `BioSequenceSlice`. This is particularly efficient when a single operation can cover all sequences at once — for example, a single HTTP request to an external server.
+
+If both `slice_worker` and `worker` are defined in the same script, `slice_worker` takes precedence.
+
+Because `BioSequence` objects are accessed by pointer, any attribute set on a sequence retrieved from the slice is immediately reflected in the slice — no reassignment is needed.
+
+The batch size is not fixed: it depends on the input file and OBITools4's dynamic flush mechanism. A `slice_worker` must always iterate up to `slice:len()` and must not assume a constant size.
+
+```lua
+local json = require("json")
+
+function slice_worker(slice)
+    -- Build a batch payload for a single HTTP request
+    local ids, seqs = {}, {}
+    for i = 0, slice:len() - 1 do
+        local s = slice:sequence(i)
+        table.insert(ids,  s:id())
+        table.insert(seqs, s:sequence())
+    end
+
+    local response, err = http.post(SERVER_URL, json.encode({ ids = ids, seqs = seqs }))
+    if err then
+        return slice  -- return the batch unmodified on error
+    end
+
+    local data = json.decode(response)
+    -- Annotate each sequence from the response
+    for i = 0, slice:len() - 1 do
+        local s = slice:sequence(i)
+        local score = data[s:id()]
+        if score then
+            s:attribute("server_score", score)
+        end
+    end
+
+    return slice
+end
+```
+
 ## The `obicontext` to share information
 
 The `obicontext` module provides a shared context for data exchange between functions and within the `worker` function. It allows you to store and retrieve values using string keys.


### PR DESCRIPTION
- Introduce `sliceWorker` as an alternative to worker for batch processing
- Explain precedence: slice_worker overridesworker when both are defined  
- Document usage in obiscript and Lua programming guides
- Include example demonstrating HTTP batch request pattern