### PR TITLE
:arrow_up::hugo upgrade to v0.159.2

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.140.2
+      HUGO_VERSION: 0.159.2
       HUGO_CACHEDIR: /tmp/hugo_cache # <- Define the env variable here, so that Hugo's cache dir is now predictible in your workflow and doesn't depend on the Hugo's version you're using.
     steps:
       - name: Checkout


### PR DESCRIPTION
- Update Hugo version from `v0.146.x` to latest stable (`v0.159.2`).
- Aligns with current Hugo release track and includes bug fixes/performance improvements.

> Note: Ensure theme compatibility before merging.