### PR TITLE
(workflow) Add required permissions for GitHub Pages deployment

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -72,6 +72,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Add contents: read, pages: write and id-token:write permissions to the deployment job in hugo.yml.

This ensures proper access for deploying static content and verifying identity via OIDC.